### PR TITLE
COM-209 Remove faulty provider

### DIFF
--- a/sql/remove_faulty_provider.sql
+++ b/sql/remove_faulty_provider.sql
@@ -1,0 +1,2 @@
+delete from provider where person_id = 2;
+delete from person where person_id = 2;


### PR DESCRIPTION
By default openmrs creates a faulty provider that doesn't have a person_name assigned to it. This script removes that faulty provider "Lab manager".

 https://talk.openmrs.org/t/provider-scheduling-page-throwing-exception/10583/3