### PR TITLE
COM-400 Add person attribute type other cause of death

### DIFF
--- a/configuration/personattributetypes/other_cause_of_death.csv
+++ b/configuration/personattributetypes/other_cause_of_death.csv
@@ -1,0 +1,2 @@
+Uuid,Void/Retire,Name,Description,Format,Foreign uuid,Searchable,Edit privilege,_order:1000
+c4c978ee-6e50-4893-a62e-50d15b0342f0,,PERSON_ATTRIBUTE_TYPE_OTHER_CAUSE_OF_DEATH,,java.lang.String,,yes,,


### PR DESCRIPTION
The new person attribute type is used to store non-coded causes of death
Jira ticket: https://jembiprojects.jira.com/browse/COM-400