### PR TITLE
COM-463 Update GP visitExpireHours to 1

### DIFF
--- a/configuration/globalproperties/emrapi.visitExpireHours.xml
+++ b/configuration/globalproperties/emrapi.visitExpireHours.xml
@@ -2,7 +2,7 @@
   <globalProperties>
     <globalProperty>
       <property>emrapi.visitExpireHours</property>
-      <value>12</value>
+      <value>1</value>
     </globalProperty>
   </globalProperties>
 </config>


### PR DESCRIPTION
The scheduler runs at 12:00 so we want all the visits to be expired by the time it runs, that's why we are updating the GP to 1.