### PR TITLE
COM-533 Fix the logic that retrieves the most recent VL result from Elis

### DIFF
--- a/sql/report_util_functions.sql
+++ b/sql/report_util_functions.sql
@@ -1306,7 +1306,7 @@ proc_vital_load:BEGIN
             AND o.value_numeric IS NOT NULL
             AND o.person_id = p_patientId
             AND (c.uuid = routineViralLoadTestUuid OR c.uuid = targetedViralLoadTestUuid OR c.uuid = notDocumentedViralLoadTestUuid)
-        ORDER BY o.value_datetime DESC
+        ORDER BY o.obs_datetime DESC
         LIMIT 1;
     END IF;
 


### PR DESCRIPTION
This PR fixes a copy/paste error. The result date from elis is stored in obs.obs_datetime (not in o.value_datetime)