### PR TITLE
COM-634 Fix retrieveViralLoadTestDateAndResult store proc

### DIFF
--- a/reportssql/report_util_functions.sql
+++ b/reportssql/report_util_functions.sql
@@ -1505,7 +1505,7 @@ proc_vital_load:BEGIN
             AND o.value_numeric IS NOT NULL
             AND o.person_id = p_patientId
             AND (c.uuid = routineViralLoadTestUuid OR c.uuid = targetedViralLoadTestUuid OR c.uuid = notDocumentedViralLoadTestUuid)
-        ORDER BY o.value_datetime, o.obs_datetime DESC
+        ORDER BY o.obs_datetime DESC
         LIMIT 1;
     ELSE
         SELECT o.value_numeric INTO p_testResult

--- a/reportssql/report_util_functions.sql
+++ b/reportssql/report_util_functions.sql
@@ -1460,7 +1460,7 @@ proc_vital_load:BEGIN
         AND o.value_datetime IS NOT NULL
         AND o.person_id = p_patientId
         AND (c.uuid = routineViralLoadTestDateUuid OR c.uuid = targetedViralLoadTestDateUuid OR c.uuid = notDocumentedViralLoadTestDateUuid)
-    ORDER BY o.value_datetime, o.obs_datetime DESC
+    ORDER BY o.value_datetime DESC, o.obs_datetime DESC
     LIMIT 1;
 
     -- read and store latest test date from elis

--- a/reportssql/report_util_functions.sql
+++ b/reportssql/report_util_functions.sql
@@ -1460,7 +1460,7 @@ proc_vital_load:BEGIN
         AND o.value_datetime IS NOT NULL
         AND o.person_id = p_patientId
         AND (c.uuid = routineViralLoadTestDateUuid OR c.uuid = targetedViralLoadTestDateUuid OR c.uuid = notDocumentedViralLoadTestDateUuid)
-    ORDER BY o.value_datetime DESC
+    ORDER BY o.value_datetime, o.obs_datetime DESC
     LIMIT 1;
 
     -- read and store latest test date from elis
@@ -1505,7 +1505,7 @@ proc_vital_load:BEGIN
             AND o.value_numeric IS NOT NULL
             AND o.person_id = p_patientId
             AND (c.uuid = routineViralLoadTestUuid OR c.uuid = targetedViralLoadTestUuid OR c.uuid = notDocumentedViralLoadTestUuid)
-        ORDER BY o.value_datetime DESC
+        ORDER BY o.value_datetime, o.obs_datetime DESC
         LIMIT 1;
     ELSE
         SELECT o.value_numeric INTO p_testResult

--- a/reportssql/report_util_functions.sql
+++ b/reportssql/report_util_functions.sql
@@ -640,7 +640,7 @@ BEGIN
         INTO testDateFromForm, encounterIdOfFormResult
     FROM obs o
     JOIN concept c ON o.concept_id = c.concept_id AND c.retired = 0
-    WHERE voided = 0
+    WHERE o.voided = 0
         AND o.order_id IS NULL
         AND o.value_datetime IS NOT NULL
         AND o.value_datetime < p_endDate
@@ -652,9 +652,9 @@ BEGIN
     SELECT o.value_numeric INTO testResultFromForm
     FROM obs o
     JOIN concept c ON o.concept_id = c.concept_id AND c.retired = 0
-    WHERE voided = 0
+    WHERE o.voided = 0
         AND o.encounter_id = encounterIdOfFormResult
-        AND order_id IS NULL
+        AND o.order_id IS NULL
         AND o.value_numeric IS NOT NULL
         AND o.person_id = p_patientId
         AND c.uuid = p_uuidViralLoadExam
@@ -667,8 +667,8 @@ BEGIN
         INTO testDateFromOpenElis, testResultFromOpenElis
     FROM obs o
     JOIN concept c ON o.concept_id = c.concept_id AND c.retired = 0
-    WHERE voided = 0
-        AND order_id IS NOT NULL
+    WHERE o.voided = 0
+        AND o.order_id IS NOT NULL
         AND o.value_numeric IS NOT NULL
         AND o.person_id = p_patientId
         AND c.uuid = p_uuidViralLoadExam
@@ -963,7 +963,7 @@ BEGIN
     SELECT TRUE INTO drugDispensed
     FROM obs o
     JOIN concept c ON o.concept_id = c.concept_id AND c.retired = 0
-    WHERE voided = 0
+    WHERE o.voided = 0
         AND o.person_id = p_patientId
         AND o.order_id = p_orderId
         AND c.uuid = uuidDispensedConcept;
@@ -1455,8 +1455,8 @@ proc_vital_load:BEGIN
     SELECT o.value_datetime INTO testDateFromForm
     FROM obs o
     JOIN concept c ON o.concept_id = c.concept_id AND c.retired = 0
-    WHERE voided = 0
-        AND order_id IS NULL
+    WHERE o.voided = 0
+        AND o.order_id IS NULL
         AND o.value_datetime IS NOT NULL
         AND o.person_id = p_patientId
         AND (c.uuid = routineViralLoadTestDateUuid OR c.uuid = targetedViralLoadTestDateUuid OR c.uuid = notDocumentedViralLoadTestDateUuid)
@@ -1467,8 +1467,8 @@ proc_vital_load:BEGIN
     SELECT o.obs_datetime INTO testDateFromOpenElis
     FROM obs o
     JOIN concept c ON o.concept_id = c.concept_id AND c.retired = 0
-    WHERE voided = 0
-        AND order_id IS NOT NULL
+    WHERE o.voided = 0
+        AND o.order_id IS NOT NULL
         AND o.value_numeric IS NOT NULL
         AND o.person_id = p_patientId
         AND (c.uuid = routineViralLoadTestUuid OR c.uuid = targetedViralLoadTestUuid OR c.uuid = notDocumentedViralLoadTestUuid)
@@ -1500,8 +1500,8 @@ proc_vital_load:BEGIN
         SELECT o.value_numeric INTO p_testResult
         FROM obs o
         JOIN concept c ON o.concept_id = c.concept_id AND c.retired = 0
-        WHERE voided = 0
-            AND order_id IS NULL
+        WHERE o.voided = 0
+            AND o.order_id IS NULL
             AND o.value_numeric IS NOT NULL
             AND o.person_id = p_patientId
             AND (c.uuid = routineViralLoadTestUuid OR c.uuid = targetedViralLoadTestUuid OR c.uuid = notDocumentedViralLoadTestUuid)
@@ -1511,8 +1511,8 @@ proc_vital_load:BEGIN
         SELECT o.value_numeric INTO p_testResult
         FROM obs o
         JOIN concept c ON o.concept_id = c.concept_id AND c.retired = 0
-        WHERE voided = 0
-            AND order_id IS NOT NULL
+        WHERE o.voided = 0
+            AND o.order_id IS NOT NULL
             AND o.value_numeric IS NOT NULL
             AND o.person_id = p_patientId
             AND (c.uuid = routineViralLoadTestUuid OR c.uuid = targetedViralLoadTestUuid OR c.uuid = notDocumentedViralLoadTestUuid)


### PR DESCRIPTION
When finding the latest manual lab test result date, it was getting the last one according to value_datetime, but it had to also check for latest o.obs_datetime in case the value_datetime was the same for 2 manual lab tests.