### PR TITLE
COM-645 Read TARV from program if it's not in patient registration

### DIFF
--- a/reportssql/defaulter_functions.sql
+++ b/reportssql/defaulter_functions.sql
@@ -221,6 +221,24 @@ BEGIN
 END$$
 DELIMITER ;
 
+-- getPatientProgramARTNumber
+
+DROP FUNCTION IF EXISTS getPatientProgramARTNumber;
+
+DELIMITER $$
+CREATE FUNCTION getPatientProgramARTNumber(
+    p_patientId INT(11)) RETURNS VARCHAR(250)
+    DETERMINISTIC
+BEGIN
+    DECLARE result VARCHAR(250);
+    DECLARE uuidProgramARTNumber VARCHAR(38) DEFAULT "c41f844e-a707-11e6-91e9-0800270d80ce";
+
+    SET result = getPatientMostRecentProgramAttributeValue(p_patientId, uuidProgramARTNumber);
+
+    RETURN (result);
+END$$
+DELIMITER ;
+
 -- patientHasEnrolledInDefaulterProgram
 
 DROP FUNCTION IF EXISTS patientHasEnrolledInDefaulterProgram;

--- a/reportssql/visit_report_functions.sql
+++ b/reportssql/visit_report_functions.sql
@@ -419,7 +419,13 @@ CREATE FUNCTION getPatientARTNumber(
     p_patientId INT(11)) RETURNS VARCHAR(50)
     DETERMINISTIC
 BEGIN
-    RETURN getPatientIdentifierValue(p_patientId, 'REGISTRATION_IDTYPE_3_ART_KEY');
+    DECLARE artNumber VARCHAR(50);
+    SET artNumber = getPatientIdentifierValue(p_patientId, 'REGISTRATION_IDTYPE_3_ART_KEY');
+    IF (artNumber IS NOT NULL) THEN
+        return artNumber;
+    ELSE
+        return getPatientProgramARTNumber(p_patientId);
+    END IF;
 END$$
 DELIMITER ;
 


### PR DESCRIPTION
Adds logic to first try retrieve the patient TARV number from the registration form, if it is not available, then reads the TARV from the program form